### PR TITLE
Render blocks in versions 2 and 3 (default)

### DIFF
--- a/ScratchblockHooks.php
+++ b/ScratchblockHooks.php
@@ -21,14 +21,28 @@ class Scratchblock4Hook {
 		$wgOut->addModules('ext.scratchBlocks4');
 	}
 
+	public static function sb4RenderTagGeneric($input, array $args, $tag) {
+		return (
+			'<'
+			. $tag
+			. ' class="blocks'
+			. (isset($args['version']) ? '-' . htmlspecialchars($args['version']) : '')
+			. '">'
+			. htmlspecialchars($input)
+			. '</'
+			. $tag
+			. '>'
+		);
+	}
+
 	// Output HTML for <scratchblocks> tag
 	public static function sb4RenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		return '<pre class="blocks">' . htmlspecialchars($input) . '</pre>';
+		return self::sb4RenderTagGeneric($input, $args, 'pre');
 	}
 
 	// Output HTML for inline <sb> tag
 	public static function sb4RenderInlineTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		return '<code class="blocks">' . htmlspecialchars($input) . '</code>';
+		return self::sb4RenderTagGeneric($input, $args, 'code');
 	}
 }
 ?>

--- a/inline.css
+++ b/inline.css
@@ -1,8 +1,8 @@
-code.blocks {
+code[class^=blocks] {
 	display: inline-block;
 }
 
-.blocks {
+#content [class^=blocks] {
 	border: none;
 	background-color: inherit;
 	overflow-x: auto;

--- a/run_scratchblocks4.js
+++ b/run_scratchblocks4.js
@@ -1,7 +1,9 @@
 function run_scratchblocks() {
-	scratchblocks.renderMatching('pre.blocks', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3'});
-	scratchblocks.renderMatching('code.blocks', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3', inline: true});
-	var items = document.querySelectorAll('.scratchblocks svg');
+	scratchblocks.renderMatching('pre.blocks, pre.blocks-3', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3'});
+	scratchblocks.renderMatching('code.blocks, code.blocks-3', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3', inline: true});
+	scratchblocks.renderMatching('pre.blocks-2', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2'});
+	scratchblocks.renderMatching('code.blocks-2', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2', inline: true});
+	var items = document.querySelectorAll('.blocks .scratchblocks svg, .blocks-3 .scratchblocks svg');
 	var item;
 	for (var i = items.length; i--;) {
 		item = items[i];

--- a/run_scratchblocks4.js
+++ b/run_scratchblocks4.js
@@ -1,9 +1,9 @@
 function run_scratchblocks() {
-	scratchblocks.renderMatching('pre.blocks, pre.blocks-3', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3'});
-	scratchblocks.renderMatching('code.blocks, code.blocks-3', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3', inline: true});
-	scratchblocks.renderMatching('pre.blocks-2', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2'});
-	scratchblocks.renderMatching('code.blocks-2', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2', inline: true});
-	var items = document.querySelectorAll('.blocks .scratchblocks svg, .blocks-3 .scratchblocks svg');
+	scratchblocks.renderMatching('pre.blocks, pre[class^=blocks-3]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3'});
+	scratchblocks.renderMatching('code.blocks, code[class^=blocks-3]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3', inline: true});
+	scratchblocks.renderMatching('pre[class^=blocks-2]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2'});
+	scratchblocks.renderMatching('code[class^=blocks-2]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2', inline: true});
+	var items = document.querySelectorAll('.blocks .scratchblocks svg, [class^=blocks-3] .scratchblocks svg');
 	var item;
 	for (var i = items.length; i--;) {
 		item = items[i];


### PR DESCRIPTION
### Changes
* Add `sb4RenderTagGeneric` to consolidate code for the placeholder pre or code
* Change CSS to match any class starting with `blocks`
* Add specific JS for versions 2 and 3, keeping the default "blocks" class as 3

### Reason for Changes
https://en.scratch-wiki.info/wiki/Scratch_Wiki_talk:Community_Portal#scratchblocks_version_parameter

### Test Coverage
![image](https://user-images.githubusercontent.com/28599280/56367114-1a89dd00-6227-11e9-8c7e-be5f2e0fe62d.png)
Renders both Scratch 2 and 3 on https://hkugawiki.ddns.net/t/index.php?title=Sandbox&oldid=3