### PR TITLE
Fix blocks appearing too big in Gecko

### DIFF
--- a/run_scratchblocks4.js
+++ b/run_scratchblocks4.js
@@ -7,8 +7,7 @@ function run_scratchblocks() {
 	var item;
 	for (var i = items.length; i--;) {
 		item = items[i];
-		item.viewBox.baseVal.width = item.width.baseVal.value;
-		item.viewBox.baseVal.height = item.children[1].getBoundingClientRect().height;
+		item.setAttribute('viewBox', '0 0 ' + item.width.baseVal.value + ' ' + item.children[1].getBoundingClientRect().height);
 		item.width.baseVal.value *= 0.675;
 		item.height.baseVal.value = item.viewBox.baseVal.height * 0.675;
 	}


### PR DESCRIPTION
Firefox and SeaMonkey don't allow modification of the viewBox attribute if it doesn't exist, so as it is the blocks aren't scaled as they should be. (I tested the code in the browser console, using the latest Firefox.)