### PR TITLE
Support live previews

### DIFF
--- a/run_scratchblocks4.js
+++ b/run_scratchblocks4.js
@@ -13,5 +13,7 @@ function run_scratchblocks() {
 	}
 }
 $.getScript('https://scratchblocks.github.io/js/scratchblocks-v3.4-min.js').done(function(){
-	$.getScript('https://scratchblocks.github.io/js/translations-all-v3.4.js').done(run_scratchblocks);
+	$.getScript('https://scratchblocks.github.io/js/translations-all-v3.4.js').done(function(){
+		mw.hook('wikipage.content').add(run_scratchblocks);
+	});
 });


### PR DESCRIPTION
Resolves #4 

MediaWiki provides a `wikipage.content` hook that is fired when page content loads, including upon reading the page and also when live preview data loads.
Register `run_scratchblocks` to this hook instead of directly to the end of the translations script.
Only register the hook after the translations script though, because page content could load before sb does, and MediaWiki retroactively fires the last event on hooks added to it post-fire.