### PR TITLE
Add setting for default block type

### DIFF
--- a/ScratchblockHooks.php
+++ b/ScratchblockHooks.php
@@ -11,8 +11,9 @@ class Scratchblock4Hook {
 	}
 
 	public static function sb4ReadLS (array &$vars) {
-		global $wgScratchBlocks4Langs;
+		global $wgScratchBlocks4Langs, $wgScratchBlocks4BlockVersion;
 		$vars['wgScratchBlocks4Langs'] = $wgScratchBlocks4Langs;
+		$vars['wgScratchBlocks4BlockVersion'] = $wgScratchBlocks4BlockVersion;
 		return true;
 	}
 

--- a/extension.json
+++ b/extension.json
@@ -43,7 +43,8 @@
 		]
 	},
 	"config": {
-		"ScratchBlocks4Langs": []
+		"ScratchBlocks4Langs": [],
+		"ScratchBlocks4BlockVersion": "3.0"
 	},
 	"manifest_version": 1
 }

--- a/run_scratchblocks4.js
+++ b/run_scratchblocks4.js
@@ -1,9 +1,23 @@
 function run_scratchblocks() {
-	scratchblocks.renderMatching('pre.blocks, pre[class^=blocks-3]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3'});
-	scratchblocks.renderMatching('code.blocks, code[class^=blocks-3]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch3', inline: true});
-	scratchblocks.renderMatching('pre[class^=blocks-2]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2'});
-	scratchblocks.renderMatching('code[class^=blocks-2]', {languages: ['en'].concat(mw.config.get('wgScratchBlocks4Langs')), style: 'scratch2', inline: true});
-	var items = document.querySelectorAll('.blocks .scratchblocks svg, [class^=blocks-3] .scratchblocks svg');
+	var version = mw.config.get('wgScratchBlocks4BlockVersion');
+	// Note: the weak equality is intentional to allow '2' and 2 both specify sb2
+	if (version == 2 || version[0] == '2') { // to handle '2.0'
+		version = 'scratch2';
+	} else {
+		version = 'scratch3';
+	}
+	var langs = ['en'].concat(mw.config.get('wgScratchBlocks4Langs'));
+	scratchblocks.renderMatching('pre.blocks', {languages: langs, style: version});
+	scratchblocks.renderMatching('code.blocks', {languages: langs, style: version, inline: true});
+	scratchblocks.renderMatching('pre[class^=blocks-3]', {languages: langs, style: 'scratch3'});
+	scratchblocks.renderMatching('code[class^=blocks-3]', {languages: langs, style: 'scratch3', inline: true});
+	scratchblocks.renderMatching('pre[class^=blocks-2]', {languages: langs, style: 'scratch2'});
+	scratchblocks.renderMatching('code[class^=blocks-2]', {languages: langs, style: 'scratch2', inline: true});
+	var query = '[class^=blocks-3] .scratchblocks svg';
+	if (version === 'scratch3') {
+		query = '.blocks .scratchblocks svg, ' + query;
+	}
+	var items = document.querySelectorAll(query);
 	var item;
 	for (var i = items.length; i--;) {
 		item = items[i];


### PR DESCRIPTION
extension.json:
* Add `$wgScratchBlocks4BlockVersion`, default "3.0"

ScratchblockHooks.php:
* Add new config var to JS

run_scratchblocks4.js:
* `*.blocks` and `*[class^=blocks-3]` now have to be rendered in separate passes because their versions may be different
* Consolidate language expression into `langs` variable because why hadn't that already been done...?
* Only shrink `.blocks` svgs if the default version is 3.0