### PR TITLE
Do not load SB scripts when the tags are not used

### DIFF
--- a/ScratchblockHooks.php
+++ b/ScratchblockHooks.php
@@ -1,4 +1,6 @@
 <?php
+define('SB4_MODULE_KEY', 'ext.scratchBlocks4');
+
 class Scratchblock4Hook {
 	// Ouput HTML for <scratchblocks> tag
 
@@ -17,7 +19,15 @@ class Scratchblock4Hook {
 		return true;
 	}
 
-	public static function sb4RenderTagGeneric($input, array $args, $tag) {
+	public static function sb4Setup(Parser $parser) {
+		$out = $parser->getOutput();
+		if (!in_array(SB4_MODULE_KEY, $out->getModules())) {
+			$out->addModules(SB4_MODULE_KEY);
+		}
+	}
+
+	public static function sb4RenderTagGeneric($input, array $args, $parser, $tag) {
+		self::sb4Setup($parser);
 		return (
 			'<'
 			. $tag
@@ -33,14 +43,12 @@ class Scratchblock4Hook {
 
 	// Output HTML for <scratchblocks> tag
 	public static function sb4RenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		$parser->getOutput()->addModules('ext.scratchBlocks4');
-		return self::sb4RenderTagGeneric($input, $args, 'pre');
+		return self::sb4RenderTagGeneric($input, $args, $parser, 'pre');
 	}
 
 	// Output HTML for inline <sb> tag
 	public static function sb4RenderInlineTag ($input, array $args, Parser $parser, PPFrame $frame) {
-		$parser->getOutput()->addModules('ext.scratchBlocks4');
-		return self::sb4RenderTagGeneric($input, $args, 'code');
+		return self::sb4RenderTagGeneric($input, $args, $parser, 'code');
 	}
 }
 ?>

--- a/ScratchblockHooks.php
+++ b/ScratchblockHooks.php
@@ -16,11 +16,6 @@ class Scratchblock4Hook {
 		return true;
 	}
 
-	public static function sb4Setup() {
-		global $wgOut;
-		$wgOut->addModules('ext.scratchBlocks4');
-	}
-
 	public static function sb4RenderTagGeneric($input, array $args, $tag) {
 		return (
 			'<'
@@ -37,11 +32,13 @@ class Scratchblock4Hook {
 
 	// Output HTML for <scratchblocks> tag
 	public static function sb4RenderTag ($input, array $args, Parser $parser, PPFrame $frame) {
+		$parser->getOutput()->addModules('ext.scratchBlocks4');
 		return self::sb4RenderTagGeneric($input, $args, 'pre');
 	}
 
 	// Output HTML for inline <sb> tag
 	public static function sb4RenderInlineTag ($input, array $args, Parser $parser, PPFrame $frame) {
+		$parser->getOutput()->addModules('ext.scratchBlocks4');
 		return self::sb4RenderTagGeneric($input, $args, 'code');
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -13,9 +13,6 @@
 	"AutoloadClasses": {
 		"Scratchblock4Hook": "ScratchblockHooks.php"
 	},
-	"ExtensionFunctions": [
-		"Scratchblock4Hook::sb4Setup"
-	],
 	"ResourceModules": {
 		"ext.scratchBlocks4": {
 			"scripts": [


### PR DESCRIPTION
Loading the SB scripts on all pages causes performance issues. This PR removes ``sb4Setup`` and moves its functionality to ``sb4RenderTag`` and ``sb4RenderInlineTag``.